### PR TITLE
feat: Facebook & Bilibili link embed modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * Context menu support
 * Reverse image search
 * Better pixiv preview (Multi image support)
+* Better embeds for Twitter, Facebook and Bilibili links
 * Currency conversion
 * Scam URL detection
 * Utilities, e.g. choices, magicball
@@ -40,3 +41,5 @@ yarn start
 |[exchangerate.host](https://exchangerate.host/)|Currency conversion|
 |[Google Safebrowsing](https://safebrowsing.google.com/)|Detect malicious URLs|
 |[FXTwitter](https://github.com/FixTweet/FixTweet)|Generate embeds from Twitter links|
+|[facebed](https://facebed.com/)|Generate embeds from Facebook links|
+|[vxbilibili](https://www.vxbilibili.com/)|Generate embeds from Bilibili links|

--- a/res/i18n/en-US.json
+++ b/res/i18n/en-US.json
@@ -204,5 +204,8 @@
   },
   "bilibili": {
     "originalVideoButton": "Original video"
+  },
+  "facebook": {
+    "originalPostButton": "Original post"
   }
 }

--- a/res/i18n/en-US.json
+++ b/res/i18n/en-US.json
@@ -201,5 +201,8 @@
   },
   "twitter": {
     "originalTweetButton": "Original tweet"
+  },
+  "bilibili": {
+    "originalVideoButton": "Original video"
   }
 }

--- a/res/i18n/zh-TW.json
+++ b/res/i18n/zh-TW.json
@@ -203,5 +203,8 @@
   },
   "bilibili": {
     "originalVideoButton": "原始影片"
+  },
+  "facebook": {
+    "originalPostButton": "原始貼文"
   }
 }

--- a/res/i18n/zh-TW.json
+++ b/res/i18n/zh-TW.json
@@ -200,5 +200,8 @@
   },
   "twitter": {
     "originalTweetButton": "原始推文"
+  },
+  "bilibili": {
+    "originalVideoButton": "原始影片"
   }
 }

--- a/src/modules/__fixtures__/facebook/login.html
+++ b/src/modules/__fixtures__/facebook/login.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html><html><head><title>Facebook</title></head>
+<body>Log in or sign up to view</body></html>

--- a/src/modules/__fixtures__/facebook/valid.html
+++ b/src/modules/__fixtures__/facebook/valid.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><html><head>
+<meta property="og:title" content="A Facebook Post"/>
+<meta property="og:description" content="some description"/>
+<meta property="og:url" content="https://www.facebook.com/reel/123"/>
+</head><body></body></html>

--- a/src/modules/bilibili.test.ts
+++ b/src/modules/bilibili.test.ts
@@ -15,9 +15,10 @@ const makeMessage = (content: string): Message => {
 
 const run = (msg: Message) => bilibili.action({ message: msg });
 
-// action probes the rewritten URL for existence via fetch(url).ok
-const stubFetch = (ok: boolean) =>
-	spyOn(globalThis, "fetch").mockResolvedValue({ ok } as Response);
+// action probes the rewritten URL: checks fetch(url).ok, then reads the body to
+// pull the canonical og:url. Default body has no og:url -> raw-rewrite fallback.
+const stubFetch = (ok: boolean, html = "") =>
+	spyOn(globalThis, "fetch").mockResolvedValue({ ok, text: async () => html } as Response);
 
 afterEach(() => mock.restore());
 
@@ -78,5 +79,24 @@ describe("bilibili.action", () => {
 		const result = await run(makeMessage("https://www.bilibili.com/opus/987654321"));
 		if (result === false) throw new Error("expected reply");
 		expect(result.result.content).toBe("https://www.vxbilibili.com/opus/987654321");
+	});
+
+	it("uses vxbilibili's canonical og:url to strip tracking params", async () => {
+		// b23.tv short link carrying tracking; vxbilibili resolves it to a clean
+		// canonical video URL in og:url.
+		stubFetch(
+			true,
+			'<meta content="https://www.bilibili.com/video/BV12nMn6ZEd6?p=1"property=og:url>'
+		);
+		const result = await run(
+			makeMessage("https://b23.tv/R9v1RBj?share_source=copy_web&buvid=XY")
+		);
+		if (result === false) throw new Error("expected reply");
+
+		// posted proxy link is the clean canonical, rewritten to vxbilibili
+		expect(result.result.content).toBe("https://www.vxbilibili.com/video/BV12nMn6ZEd6?p=1");
+		// button points at the untracked original
+		const button = (result.result.components?.[0] as any).components[0];
+		expect(button.url).toBe("https://www.bilibili.com/video/BV12nMn6ZEd6?p=1");
 	});
 });

--- a/src/modules/bilibili.test.ts
+++ b/src/modules/bilibili.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, mock, spyOn, afterEach } from "bun:test";
+import { bilibili } from "@module/bilibili";
+import type { Message } from "discord.js";
+
+const makeMessage = (content: string): Message => {
+	const msg = {
+		id: "msg-1",
+		content,
+		embeds: [],
+		suppressEmbeds: mock(async () => {}),
+		channel: { messages: { fetch: mock(async () => msg) } }
+	};
+	return msg as unknown as Message;
+};
+
+const run = (msg: Message) => bilibili.action({ message: msg });
+
+// action probes the rewritten URL for existence via fetch(url).ok
+const stubFetch = (ok: boolean) =>
+	spyOn(globalThis, "fetch").mockResolvedValue({ ok } as Response);
+
+afterEach(() => mock.restore());
+
+describe("bilibili.action", () => {
+	it("returns false for non-bilibili link", async () => {
+		expect(await run(makeMessage("https://example.com/foo"))).toBe(false);
+	});
+
+	it("rejects unsupported bilibili path", async () => {
+		// /account is not an embeddable content path
+		expect(await run(makeMessage("https://www.bilibili.com/account"))).toBe(false);
+	});
+
+	it("rejects when vxbilibili reports the link does not exist", async () => {
+		stubFetch(false);
+		expect(await run(makeMessage("https://www.bilibili.com/video/BV0000000000"))).toBe(false);
+	});
+
+	it("rejects when the existence probe throws", async () => {
+		spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+		expect(await run(makeMessage("https://www.bilibili.com/video/BV1xx411c7mD"))).toBe(false);
+	});
+
+	it("rewrites a video link to vxbilibili and keeps the path", async () => {
+		stubFetch(true);
+		const msg = makeMessage("https://www.bilibili.com/video/BV1xx411c7mD");
+		const result = await run(msg);
+
+		if (result === false) throw new Error("expected reply");
+		expect(result.type).toBe("reply");
+		expect(result.result.content).toBe("https://www.vxbilibili.com/video/BV1xx411c7mD");
+		expect(msg.suppressEmbeds).toHaveBeenCalled();
+	});
+
+	it("preserves query params (multi-page videos)", async () => {
+		stubFetch(true);
+		const result = await run(makeMessage("https://www.bilibili.com/video/BV1xx?p=2"));
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.content).toBe("https://www.vxbilibili.com/video/BV1xx?p=2");
+	});
+
+	it("rewrites b23.tv short links (any path)", async () => {
+		stubFetch(true);
+		const result = await run(makeMessage("https://b23.tv/abcd123"));
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.content).toBe("https://vxb23.tv/abcd123");
+	});
+
+	it("rewrites subdomain content (live streams)", async () => {
+		stubFetch(true);
+		const result = await run(makeMessage("https://live.bilibili.com/12345"));
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.content).toBe("https://live.vxbilibili.com/12345");
+	});
+
+	it("rewrites opus posts", async () => {
+		stubFetch(true);
+		const result = await run(makeMessage("https://www.bilibili.com/opus/987654321"));
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.content).toBe("https://www.vxbilibili.com/opus/987654321");
+	});
+});

--- a/src/modules/bilibili.ts
+++ b/src/modules/bilibili.ts
@@ -1,0 +1,131 @@
+import { t } from "@app/i18n/token";
+import type { StealthModule } from "@type/StealthModule";
+import type { ActionRowData, MessageActionRowComponentData } from "discord.js";
+import { ButtonStyle, ComponentType } from "discord.js";
+import { find } from "linkifyjs";
+import { Logger } from "tslog";
+
+const logger = new Logger({
+	name: "bilibili",
+	minLevel: Bun.env.NODE_ENV === "production" ? 3 : 0
+});
+
+// vxbilibili fixes bilibili embeds by inserting "vx" before the domain:
+//   www.bilibili.com/video/BVxxx -> www.vxbilibili.com/video/BVxxx
+//   b23.tv/xxx                   -> vxb23.tv/xxx
+const rewriteHostname = (hostname: string): string | null => {
+	if (hostname.endsWith("bilibili.com")) {
+		return hostname.replace("bilibili.com", "vxbilibili.com");
+	}
+	if (hostname === "b23.tv" || hostname.endsWith(".b23.tv")) {
+		return hostname.replace("b23.tv", "vxb23.tv");
+	}
+	return null;
+};
+
+// Full-site links must point at embeddable content. b23.tv short links are
+// opaque redirects, so they are always accepted.
+const isSupportedBilibiliPath = (hostname: string, path: string): boolean => {
+	// Subdomains (live streams, user spaces) carry the content in the host.
+	if (/^(live|space|t)\.bilibili\.com$/.test(hostname)) {
+		return true;
+	}
+
+	return (
+		path.startsWith("/video/") ||
+		path.startsWith("/bangumi/") ||
+		path.startsWith("/opus/") ||
+		path.startsWith("/read/") ||
+		path.startsWith("/festival/")
+	);
+};
+
+export const bilibili: StealthModule = {
+	name: "bilibili",
+	event: "messageCreate",
+	action: async (obj) => {
+		const url = find(obj.message.content)
+			.filter(result => result.type === "url")
+			.map(result => new URL(result.href))
+			.filter(url =>
+				url.hostname.endsWith("bilibili.com") ||
+				url.hostname === "b23.tv" ||
+				url.hostname.endsWith(".b23.tv")
+			)[0];
+
+		if (!url) {
+			return false;
+		}
+
+		logger.debug("Found bilibili link", url.href);
+
+		const isShortLink = url.hostname === "b23.tv" || url.hostname.endsWith(".b23.tv");
+
+		if (!isShortLink && !isSupportedBilibiliPath(url.hostname, url.pathname)) {
+			logger.debug("Rejected: Unsupported bilibili path", url.pathname);
+			return false;
+		}
+
+		const newHostname = rewriteHostname(url.hostname);
+		if (!newHostname) {
+			logger.debug("Rejected: Unable to rewrite hostname", url.hostname);
+			return false;
+		}
+
+		const fixedUrl = new URL(url.href);
+		fixedUrl.hostname = newHostname;
+
+		// vxbilibili returns 200 with og metadata for real content, and 4xx
+		// ("Video not found" / "Invalid video ID" / "Not found") otherwise.
+		// Reject before replacing so dead links keep Discord's default behaviour.
+		let exists: boolean;
+		try {
+			// vxbilibili only serves the og/404 path to bot user-agents; other UAs
+			// get a 307 redirect to bilibili.com, which hides the existence signal.
+			const res = await fetch(fixedUrl.href, {
+				headers: {
+					"User-Agent": "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
+				}
+			});
+			exists = res.ok;
+		} catch (e) {
+			logger.error("Failed to check validity", e);
+			return false;
+		}
+
+		if (!exists) {
+			logger.debug("Rejected: vxbilibili reports link does not exist", fixedUrl.href);
+			return false;
+		}
+
+		const components: ActionRowData<MessageActionRowComponentData>[] = [
+			{
+				type: ComponentType.ActionRow,
+				components: [
+					{
+						type: ComponentType.Button,
+						label: t("bilibili.originalVideoButton"),
+						style: ButtonStyle.Link,
+						url: url.href
+					}
+				]
+			}
+		];
+
+		try {
+			await obj.message.suppressEmbeds();
+		} catch (e) {
+			logger.error("Failed to suppress embeds", e);
+		}
+
+		logger.debug("Accepted", fixedUrl.href);
+
+		return {
+			type: "reply",
+			result: {
+				content: fixedUrl.href,
+				components
+			}
+		};
+	}
+};

--- a/src/modules/bilibili.ts
+++ b/src/modules/bilibili.ts
@@ -1,4 +1,5 @@
 import { t } from "@app/i18n/token";
+import { extractOgUrl } from "@app/utils";
 import type { StealthModule } from "@type/StealthModule";
 import type { ActionRowData, MessageActionRowComponentData } from "discord.js";
 import { ButtonStyle, ComponentType } from "discord.js";
@@ -78,7 +79,7 @@ export const bilibili: StealthModule = {
 		// vxbilibili returns 200 with og metadata for real content, and 4xx
 		// ("Video not found" / "Invalid video ID" / "Not found") otherwise.
 		// Reject before replacing so dead links keep Discord's default behaviour.
-		let exists: boolean;
+		let html: string;
 		try {
 			// vxbilibili only serves the og/404 path to bot user-agents; other UAs
 			// get a 307 redirect to bilibili.com, which hides the existence signal.
@@ -87,15 +88,32 @@ export const bilibili: StealthModule = {
 					"User-Agent": "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
 				}
 			});
-			exists = res.ok;
+			if (!res.ok) {
+				logger.debug("Rejected: vxbilibili reports link does not exist", fixedUrl.href);
+				return false;
+			}
+			html = await res.text();
 		} catch (e) {
 			logger.error("Failed to check validity", e);
 			return false;
 		}
 
-		if (!exists) {
-			logger.debug("Rejected: vxbilibili reports link does not exist", fixedUrl.href);
-			return false;
+		// vxbilibili's og:url is the canonical, tracking-free bilibili link (short
+		// links resolved, share/buvid params dropped). Prefer it for the button and
+		// the posted proxy link; fall back to the raw rewrite if it is missing.
+		const canonical = extractOgUrl(html);
+		let content = fixedUrl.href;
+		let originalUrl = url.href;
+		if (canonical) {
+			originalUrl = canonical;
+			try {
+				const cleanProxy = new URL(canonical);
+				const cleanHostname = rewriteHostname(cleanProxy.hostname);
+				if (cleanHostname) {
+					cleanProxy.hostname = cleanHostname;
+					content = cleanProxy.href;
+				}
+			} catch { /* keep fixedUrl.href */ }
 		}
 
 		const components: ActionRowData<MessageActionRowComponentData>[] = [
@@ -106,7 +124,7 @@ export const bilibili: StealthModule = {
 						type: ComponentType.Button,
 						label: t("bilibili.originalVideoButton"),
 						style: ButtonStyle.Link,
-						url: url.href
+						url: originalUrl
 					}
 				]
 			}
@@ -118,12 +136,12 @@ export const bilibili: StealthModule = {
 			logger.error("Failed to suppress embeds", e);
 		}
 
-		logger.debug("Accepted", fixedUrl.href);
+		logger.debug("Accepted", content);
 
 		return {
 			type: "reply",
 			result: {
-				content: fixedUrl.href,
+				content,
 				components
 			}
 		};

--- a/src/modules/facebook.test.ts
+++ b/src/modules/facebook.test.ts
@@ -52,6 +52,9 @@ describe("facebook.action", () => {
 		if (result === false) throw new Error("expected reply");
 		expect(result.type).toBe("reply");
 		expect(result.result.content).toBe("https://facebed.com/reel/123");
+		// button links to facebed's canonical (tracking-free) og:url
+		const button = (result.result.components?.[0] as any).components[0];
+		expect(button.url).toBe("https://www.facebook.com/reel/123");
 		expect(msg.suppressEmbeds).toHaveBeenCalled();
 	});
 

--- a/src/modules/facebook.test.ts
+++ b/src/modules/facebook.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
+import { facebook } from "@module/facebook";
+import type { Message } from "discord.js";
+
+const dir = `${import.meta.dir}/__fixtures__/facebook`;
+const loadHtml = (name: string) => Bun.file(`${dir}/${name}.html`).text();
+
+const makeMessage = (content: string): Message => {
+	const msg = {
+		id: "msg-1",
+		content,
+		embeds: [],
+		suppressEmbeds: mock(async () => {}),
+		channel: { messages: { fetch: mock(async () => msg) } }
+	};
+	return msg as unknown as Message;
+};
+
+// action fetches facebed HTML via fetch(url).then(r => r.text())
+const stubFetch = (html: string) =>
+	spyOn(globalThis, "fetch").mockResolvedValue({ text: async () => html } as Response);
+
+const run = (msg: Message) => facebook.action({ message: msg });
+
+beforeEach(() => {
+	spyOn(Bun, "sleep").mockResolvedValue(undefined as never);
+});
+afterEach(() => mock.restore());
+
+describe("facebook.action", () => {
+	it("returns false for non-facebook link", async () => {
+		stubFetch(await loadHtml("valid"));
+		expect(await run(makeMessage("https://example.com/foo"))).toBe(false);
+	});
+
+	it("rejects unsupported facebook path", async () => {
+		stubFetch(await loadHtml("valid"));
+		// /me is not in the supported path list
+		expect(await run(makeMessage("https://www.facebook.com/me"))).toBe(false);
+	});
+
+	it("rejects when facebed returns a login wall", async () => {
+		stubFetch(await loadHtml("login"));
+		expect(await run(makeMessage("https://www.facebook.com/reel/123"))).toBe(false);
+	});
+
+	it("accepts supported path with valid facebed content", async () => {
+		stubFetch(await loadHtml("valid"));
+		const msg = makeMessage("https://www.facebook.com/reel/123");
+		const result = await run(msg);
+
+		if (result === false) throw new Error("expected reply");
+		expect(result.type).toBe("reply");
+		expect(result.result.content).toBe("https://facebed.com/reel/123");
+		expect(msg.suppressEmbeds).toHaveBeenCalled();
+	});
+
+	it("accepts /groups/... post path", async () => {
+		stubFetch(await loadHtml("valid"));
+		const result = await run(makeMessage("https://www.facebook.com/groups/1/posts/2"));
+		expect(result).not.toBe(false);
+	});
+});

--- a/src/modules/facebook.ts
+++ b/src/modules/facebook.ts
@@ -1,0 +1,190 @@
+import { t } from "@app/i18n/token";
+import type { StealthModule } from "@type/StealthModule";
+import type { ActionRowData, MessageActionRowComponentData } from "discord.js";
+import { ButtonStyle, ComponentType } from "discord.js";
+import { find } from "linkifyjs";
+import { Logger } from "tslog";
+
+const logger = new Logger({
+	name: "facebook",
+	minLevel: Bun.env.NODE_ENV === "production" ? 3 : 0
+});
+
+export const facebook: StealthModule = {
+	name: "facebook",
+	event: "messageCreate",
+	action: async (obj) => {
+		const url = find(obj.message.content)
+			.filter(result => result.type === "url")
+			.map(result => new URL(result.href))
+			.filter(url => 
+				[
+					"facebook.com",
+					"www.facebook.com",
+					"m.facebook.com"
+				].includes(url.hostname)
+			)[0];
+
+		if (!url) {
+			return false;
+		}
+
+		// Validate path based on Facebed supported paths
+		const path = url.pathname;
+		const isSupported = 
+			/^\/groups\/.+/.test(path) ||
+			path.startsWith("/permalink.php") ||
+			path.startsWith("/story.php") ||
+			/^\/.+\/posts\/.+/.test(path) ||
+			path.startsWith("/photo") ||
+			path.startsWith("/reel") ||
+			path.startsWith("/watch") ||
+			path.startsWith("/share") ||
+			path.startsWith("/videos");
+
+		if (!isSupported) {
+			logger.debug("Rejected: Unsupported Facebook path", path);
+			return false;
+		}
+
+		logger.debug("Found facebook link", url.href);
+
+		// Construct Facebed URL
+		const facebedUrl = new URL(url.href);
+		facebedUrl.hostname = "facebed.com";
+
+		// Fetch response in background
+		const [html, ] = await Promise.all([
+			(async () => {
+				try {
+					return fetch(facebedUrl.href, {
+						headers: {
+							"User-Agent": "Mozilla/5.0 (compatible; BckBot; +https://github.com/hker9527/bckbot)"
+						}
+					}).then(r => r.text());
+				} catch (e) {
+					logger.error("Failed to check validity", e);
+					return null;
+				}
+			})(),
+			new Promise<boolean>(async (resolve) => {
+				try {
+					// Wait for Discord to attempt embedding
+					await Bun.sleep(2000);
+					
+					// Re-fetch message to check for embeds
+					obj.message = await obj.message.channel.messages.fetch(obj.message.id);
+
+					// Check if we already have a valid image/video embed
+					const hasValidEmbed = obj.message.embeds.some(embed => 
+						(embed.image || embed.video || embed.thumbnail)
+					);
+
+					if (hasValidEmbed) {
+						// Optional: You could still replace it if you think Facebed is better, 
+						// but to avoid spam, we might want to skip if Discord did a good job.
+						// However, Facebook embeds are often just thumbnails. 
+						// For now, let's proceed with replacement as Facebed is likely preferred.
+						logger.debug("Message has embed, but forcing Facebed for better quality");
+					}
+					resolve(hasValidEmbed);
+				} catch (e) {
+					logger.error("Error checking message embeds", e);
+					resolve(false);
+				}
+			})
+		]);
+
+		if (html === null) {
+			logger.debug("Rejected: Failed to fetch Facebed URL");
+			return false;
+		}
+		
+		if (html.includes("Log in or sign up to view")) {
+			logger.debug("Rejected: Facebed requires login for this content. Not found?");
+			return false;
+		}
+
+		/* 
+			<meta property="og:title" content="方吉君速報-我笑故我在"/>
+			<meta property="og:description" content="你幹嘛用這麼萌的姿勢在等著我呢!!??"/>
+			<meta property="og:site_name" content="facebed by pi.kt
+	⌚ 2026/02/01 12:36:43 UTC+07
+	❤ 258 • 💬 4 • 🔁 22"/>
+			<meta property="og:url" content="https://www.facebook.com/reel/1291147629701426"/>
+		*/
+
+		/* Embed component with video
+		
+		[
+    {
+        "type": 17,
+        "id": 1,
+        "accent_color": null,
+        "components": [
+            {
+                "type": 12,
+                "id": 2,
+                "items": [
+                    {
+                        "media": {
+                            "id": "1468122329031770247",
+                            "url": "https://ifx.up.railway.app/p/DUQKICCivUt/media/0",
+                            "proxy_url": "https://images-ext-1.discordapp.net/external/HLdFKFSNzPfufo4E_tdfNuuz3ttjY8E0wKsRiZ_qK5s/https/ifx.up.railway.app/p/DUQKICCivUt/media/0",
+                            "width": 720,
+                            "height": 1280,
+                            "placeholder": "o/cJHAZqNmb3WGRneGmYcIYfOA==",
+                            "placeholder_version": 1,
+                            "content_scan_metadata": {
+                                "version": 4,
+                                "flags": 0
+                            },
+                            "content_type": "video/mp4",
+                            "loading_state": 2,
+                            "flags": 0
+                        },
+                        "description": null,
+                        "spoiler": false
+                    }
+                ]
+            },
+            {
+                "type": 10,
+                "id": 6,
+                "content": "-# <:instagram:1407043421599699036>"
+            }
+        ],
+        "spoiler": false
+    }
+]*/
+		const components: ActionRowData<MessageActionRowComponentData>[] = [
+			{
+				type: ComponentType.ActionRow,
+				components: [
+					{
+						type: ComponentType.Button,
+						label: t("facebook.originalPostButton"), // Make sure to add this key to localization if needed, or use string
+						style: ButtonStyle.Link,
+						url: url.href
+					}
+				]
+			}
+		];
+
+		try {
+			await obj.message.suppressEmbeds();
+		} catch (e) {
+			logger.error("Failed to suppress embeds", e);
+		}
+
+		logger.debug("Accepted");
+		
+		return {
+			type: "reply",
+			result: {
+				content: facebedUrl.href,
+				components
+			}
+		};
+	}
+};

--- a/src/modules/facebook.ts
+++ b/src/modules/facebook.ts
@@ -1,4 +1,5 @@
 import { t } from "@app/i18n/token";
+import { extractOgUrl } from "@app/utils";
 import type { StealthModule } from "@type/StealthModule";
 import type { ActionRowData, MessageActionRowComponentData } from "discord.js";
 import { ButtonStyle, ComponentType } from "discord.js";
@@ -105,7 +106,21 @@ export const facebook: StealthModule = {
 			return false;
 		}
 
-		/* 
+		// Facebed's og:url is the canonical, tracking-free facebook link (fbclid /
+		// mibextid / share params dropped). Prefer it for the button and the posted
+		// facebed link; fall back to the raw rewrite if it is missing.
+		const canonical = extractOgUrl(html);
+		let originalUrl = url.href;
+		if (canonical) {
+			originalUrl = canonical;
+			try {
+				const cleanProxy = new URL(canonical);
+				cleanProxy.hostname = "facebed.com";
+				facebedUrl.href = cleanProxy.href;
+			} catch { /* keep the raw facebedUrl */ }
+		}
+
+		/*
 			<meta property="og:title" content="方吉君速報-我笑故我在"/>
 			<meta property="og:description" content="你幹嘛用這麼萌的姿勢在等著我呢!!??"/>
 			<meta property="og:site_name" content="facebed by pi.kt
@@ -163,9 +178,9 @@ export const facebook: StealthModule = {
 				components: [
 					{
 						type: ComponentType.Button,
-						label: t("facebook.originalPostButton"), // Make sure to add this key to localization if needed, or use string
+						label: t("facebook.originalPostButton"),
 						style: ButtonStyle.Link,
-						url: url.href
+						url: originalUrl
 					}
 				]
 			}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,5 +1,6 @@
 import type { StealthModule } from "@type/StealthModule";
 import { bilibili } from "./bilibili";
+import { facebook } from "./facebook";
 import { moebooru } from "./moebooru";
 import { pixiv } from "./pixiv";
 import { scam } from "./scam";
@@ -7,6 +8,7 @@ import { twitter } from "./twitter";
 
 export const modules: StealthModule[] = [
 	bilibili,
+	facebook,
 	moebooru,
 	pixiv,
 	scam,

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,10 +1,12 @@
 import type { StealthModule } from "@type/StealthModule";
+import { bilibili } from "./bilibili";
 import { moebooru } from "./moebooru";
 import { pixiv } from "./pixiv";
 import { scam } from "./scam";
 import { twitter } from "./twitter";
 
 export const modules: StealthModule[] = [
+	bilibili,
 	moebooru,
 	pixiv,
 	scam,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,17 @@ export const enumStringKeys = <T extends object>(e: T) => {
 	return Object.keys(e).filter(value => isNaN(Number(value))) as (keyof T)[];
 };
 
+// Pull the canonical `og:url` out of an HTML document. Embed proxies (facebed,
+// vxbilibili) resolve links to a tracking-free canonical URL and expose it here,
+// so this is how we recover the "clean" original link. Handles both attribute
+// orders (`property` before or after `content`). Returns null if absent.
+export const extractOgUrl = (html: string): string | null => {
+	const match =
+		/<meta[^>]*\bproperty=["']?og:url["']?[^>]*\bcontent=["']([^"']+)["']/i.exec(html) ??
+		/<meta[^>]*\bcontent=["']([^"']+)["'][^>]*\bproperty=["']?og:url["']?/i.exec(html);
+	return match ? match[1] : null;
+};
+
 // Use k, m, ... suffixes for numbers
 export const num2str = (num: number) => {
 	if (num < 1000) return num.toString();


### PR DESCRIPTION
## Summary

Two new stealth modules that rewrite links to embed-friendly proxies so Discord renders proper previews, plus tracking-free canonical linking for both.

- **Bilibili** — rewrites `bilibili.com` / `b23.tv` links to [vxbilibili](https://www.vxbilibili.com/) (BiliFix). Supports video, bangumi, opus, read, festival paths, `live`/`space`/`t` subdomains, and `b23.tv` short links; preserves query params (multi-page `?p=`). Probes the rewritten URL with a Discordbot UA first — vxbilibili returns 200 with og metadata for real content and 4xx otherwise — so dead links keep Discord's default behaviour.
- **Facebook** — rewrites supported `facebook.com` links (reels, videos, photos, posts, groups, share, watch, permalink/story) to [facebed](https://facebed.com/). Fetches facebed first to reject login-wall / not-found responses, suppresses the original embed, replies with a link button.
- **Tracking-free links** — both proxies expose the resolved, de-tracked link as `og:url` (short links resolved; `share_source`/`buvid`/`fbclid`/`mibextid` dropped). A shared `extractOgUrl` helper feeds that canonical into both the "original" button and the posted proxy link, with a fallback to the raw rewrite when `og:url` is absent.

Both modules register in the module list, ship en-US / zh-TW button strings, and are documented in the README.

## Commits

- `feat(bilibili)` — bilibili module + wiring + i18n
- `feat(facebook)` — facebook module + wiring + i18n
- `docs(readme)` — functionalities line + APIs table rows
- `feat(modules)` — link to tracking-free canonical via `og:url`

## Testing

`bun test` — 51 pass, 2 skip, 0 fail. Action tests cover URL rewriting, path gating, existence-probe rejection (4xx / network throw), short-link handling, and canonical de-tracking (button + posted link).