### PR TITLE
twitter: Adjusting trigger criterias based on new Twitter embed behavior

### DIFF
--- a/src/modules/__fixtures__/twitter/embed-sensitive-placeholder.json
+++ b/src/modules/__fixtures__/twitter/embed-sensitive-placeholder.json
@@ -1,0 +1,26 @@
+{
+	"type": "rich",
+	"url": "https://twitter.com/CosplayerBunbun/status/2091473283229376570",
+	"description": "Post",
+	"color": 1942002,
+	"timestamp": "2026-08-23T10:31:03.073000+00:00",
+	"author": {
+		"name": "Post",
+		"url": "https://x.com/i"
+	},
+	"image": {
+		"url": "https://abs.twimg.com/rweb/ssr/default/v2/og/image.png",
+		"proxy_url": "https://images-ext-1.discordapp.net/external/MYAi6648nXT8SCRSSg3uMdnz1zcVJunGHw7FjNLH8sk/https/abs.twimg.com/rweb/ssr/default/v2/og/image.png",
+		"width": 1202,
+		"height": 634,
+		"content_type": "image/png",
+		"placeholder": "CggGBICLdGM6dF+62jjyoycfSQ==",
+		"placeholder_version": 1,
+		"flags": 0
+	},
+	"footer": {
+		"text": "X",
+		"icon_url": "https://abs.twimg.com/responsive-web/client-web/icon-default.522d363a.png",
+		"proxy_icon_url": "https://images-ext-1.discordapp.net/external/PTMEN2KUDPVc1f15BqpREEpYn-iIisxHLwkH_jLnaPo/https/abs.twimg.com/responsive-web/client-web/icon-default.522d363a.png"
+	}
+}

--- a/src/modules/__fixtures__/twitter/load.ts
+++ b/src/modules/__fixtures__/twitter/load.ts
@@ -5,6 +5,10 @@
 // video-vanilla.json  — real fxtwitter response, SpaceX launch (video only)
 // video-sensitive.json — real fxtwitter response, possibly_sensitive video tweet.
 //                       NSFW media urls; used for schema shape and the NSFW gate only.
+// photo-sensitive.json — real fxtwitter response, possibly_sensitive single-photo
+//                       tweet. The exact case the placeholder embed breaks: X
+//                       unfurls the placeholder, the single-photo gate then skips
+//                       the tweet and the user sees only grey. NSFW media url.
 //
 // Raw fixtures are captured live ONCE and committed, so tests exercise real API
 // shape without depending on those tweets staying up. Variant helpers below clone

--- a/src/modules/__fixtures__/twitter/load.ts
+++ b/src/modules/__fixtures__/twitter/load.ts
@@ -1,7 +1,10 @@
 // Fixture loader for twitter tests.
 //
-// text-vanilla.json  — real fxtwitter response, @jack/status/20 (first tweet, text only)
-// photo-vanilla.json — real fxtwitter response, Obama "Four more years" (single photo)
+// text-vanilla.json   — real fxtwitter response, @jack/status/20 (first tweet, text only)
+// photo-vanilla.json  — real fxtwitter response, Obama "Four more years" (single photo)
+// video-vanilla.json  — real fxtwitter response, SpaceX launch (video only)
+// video-sensitive.json — real fxtwitter response, possibly_sensitive video tweet.
+//                       NSFW media urls; used for schema shape and the NSFW gate only.
 //
 // Raw fixtures are captured live ONCE and committed, so tests exercise real API
 // shape without depending on those tweets staying up. Variant helpers below clone
@@ -16,6 +19,13 @@ export type Envelope = {
 };
 
 export const loadFixture = async (name: string): Promise<Envelope> =>
+	Bun.file(`${dir}/${name}.json`).json();
+
+// embed-sensitive-placeholder.json — real Discord embed captured from a message
+// linking a sensitive tweet. X serves a generic open graph image instead of the
+// media, and it has real dimensions, so it counts as a rendered photo unless
+// filtered by url.
+export const loadEmbed = async (name: string): Promise<Record<string, any>> =>
 	Bun.file(`${dir}/${name}.json`).json();
 
 const clone = (fx: Envelope): Envelope => structuredClone(fx);

--- a/src/modules/__fixtures__/twitter/photo-sensitive.json
+++ b/src/modules/__fixtures__/twitter/photo-sensitive.json
@@ -1,0 +1,105 @@
+{
+  "code": 200,
+  "message": "OK",
+  "tweet": {
+    "url": "https://x.com/mNk_DiSuKyamaDa/status/2091470306557018144",
+    "id": "2091470306557018144",
+    "text": "",
+    "raw_text": {
+      "text": "https://t.co/jUL7Wlb6xD",
+      "display_text_range": [
+        0,
+        0
+      ],
+      "facets": [
+        {
+          "type": "media",
+          "indices": [
+            0,
+            23
+          ],
+          "id": "2091470301477646337",
+          "display": "pic.x.com/jUL7Wlb6xD",
+          "original": "https://t.co/jUL7Wlb6xD",
+          "replacement": "https://x.com/mNk_DiSuKyamaDa/status/2091470306557018144/photo/1"
+        }
+      ]
+    },
+    "author": {
+      "screen_name": "mNk_DiSuKyamaDa",
+      "url": "https://x.com/mNk_DiSuKyamaDa",
+      "id": "1497112404513406976",
+      "followers": 116914,
+      "following": 5279,
+      "likes": 66897,
+      "media_count": 395,
+      "name": "レインボーゴレイヌ",
+      "description": "避難用@rainbow_GOREIn 【pixiv】https://www.pixiv.net/users/113154299",
+      "raw_description": {
+        "text": "避難用@rainbow_GOREIn 【pixiv】https://t.co/551kU1d0bj",
+        "facets": [
+          {
+            "type": "url",
+            "indices": [
+              26,
+              49
+            ],
+            "original": "https://t.co/551kU1d0bj",
+            "replacement": "https://www.pixiv.net/users/113154299",
+            "display": "pixiv.net/users/113154299"
+          }
+        ]
+      },
+      "location": "",
+      "banner_url": "https://pbs.twimg.com/profile_banners/1497112404513406976/1729480528",
+      "avatar_url": "https://pbs.twimg.com/profile_images/1871773203120713729/_aLA0Tfa_200x200.jpg",
+      "joined": "Fri Feb 25 07:33:20 +0000 2022",
+      "protected": false,
+      "website": null,
+      "verification": {
+        "verified": true,
+        "verified_at": null,
+        "type": "individual"
+      },
+      "avatar_color": null
+    },
+    "replies": 18,
+    "retweets": 2029,
+    "likes": 21428,
+    "bookmarks": 5631,
+    "quotes": 7,
+    "created_at": "Sun Aug 23 10:19:13 +0000 2026",
+    "created_timestamp": 1787480353,
+    "possibly_sensitive": true,
+    "views": 193052,
+    "is_note_tweet": false,
+    "community_note": null,
+    "lang": null,
+    "replying_to": null,
+    "replying_to_status": null,
+    "media": {
+      "all": [
+        {
+          "type": "photo",
+          "id": "2091470301477646337",
+          "url": "https://pbs.twimg.com/media/HQZlKHnasAETrUV.jpg?name=orig",
+          "width": 1429,
+          "height": 2048
+        }
+      ],
+      "photos": [
+        {
+          "type": "photo",
+          "id": "2091470301477646337",
+          "url": "https://pbs.twimg.com/media/HQZlKHnasAETrUV.jpg?name=orig",
+          "width": 1429,
+          "height": 2048
+        }
+      ]
+    },
+    "twitter_card": "summary_large_image",
+    "color": null,
+    "provider": "twitter",
+    "reposted_by": null
+  }
+}

--- a/src/modules/__fixtures__/twitter/video-sensitive.json
+++ b/src/modules/__fixtures__/twitter/video-sensitive.json
@@ -1,0 +1,240 @@
+{
+  "code": 200,
+  "message": "OK",
+  "tweet": {
+    "url": "https://x.com/CosplayerBunbun/status/2091473283229376570",
+    "id": "2091473283229376570",
+    "text": "💚🤍",
+    "raw_text": {
+      "text": "💚🤍 https://t.co/tuj1YsTbL5",
+      "display_text_range": [
+        0,
+        2
+      ],
+      "facets": [
+        {
+          "type": "media",
+          "indices": [
+            3,
+            26
+          ],
+          "id": "2091386788502003712",
+          "display": "pic.x.com/tuj1YsTbL5",
+          "original": "https://t.co/tuj1YsTbL5",
+          "replacement": "https://x.com/CosplayerBunbun/status/2091473283229376570/video/1"
+        }
+      ]
+    },
+    "author": {
+      "screen_name": "CosplayerBunbun",
+      "url": "https://x.com/CosplayerBunbun",
+      "id": "1763823767074353152",
+      "followers": 439285,
+      "following": 232,
+      "likes": 7694,
+      "media_count": 399,
+      "name": "ぶんちゃん🔞@ぶんコス",
+      "description": "可愛いとエロが融合したえっちな動画を作ります💙 fantia(https://x.gd/zyTwk) Fansly(https://fansly.com/CosplayBunBun) もっとぶんを知りたい人向け(サブ垢)@CosplayBunChan",
+      "raw_description": {
+        "text": "可愛いとエロが融合したえっちな動画を作ります💙 fantia(https://t.co/H9WxdWKM1W) Fansly(https://t.co/xyQvSBsaRl) もっとぶんを知りたい人向け(サブ垢)@CosplayBunChan",
+        "facets": [
+          {
+            "type": "url",
+            "indices": [
+              31,
+              54
+            ],
+            "original": "https://t.co/H9WxdWKM1W",
+            "replacement": "https://x.gd/zyTwk",
+            "display": "x.gd/zyTwk"
+          },
+          {
+            "type": "url",
+            "indices": [
+              63,
+              86
+            ],
+            "original": "https://t.co/xyQvSBsaRl",
+            "replacement": "https://fansly.com/CosplayBunBun",
+            "display": "fansly.com/CosplayBunBun"
+          }
+        ]
+      },
+      "location": "",
+      "banner_url": "",
+      "avatar_url": "https://pbs.twimg.com/profile_images/2008482393834090497/EAf6vZ6N_200x200.jpg",
+      "joined": "Sat Mar 02 07:09:07 +0000 2024",
+      "protected": false,
+      "website": {
+        "url": "https://lit.link/CosplayerBunbun",
+        "display_url": "lit.link/CosplayerBunbun"
+      },
+      "verification": {
+        "verified": true,
+        "verified_at": null,
+        "type": "individual"
+      },
+      "avatar_color": null
+    },
+    "replies": 14,
+    "retweets": 2441,
+    "likes": 42223,
+    "bookmarks": 23024,
+    "quotes": 12,
+    "created_at": "Sun Aug 23 10:31:03 +0000 2026",
+    "created_timestamp": 1787481063,
+    "possibly_sensitive": true,
+    "views": 461258,
+    "is_note_tweet": false,
+    "community_note": null,
+    "lang": null,
+    "replying_to": null,
+    "replying_to_status": null,
+    "media": {
+      "all": [
+        {
+          "id": "2091386788502003712",
+          "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/1080x1920/Z0YlFuuWnsWTyeis.mp4?tag=29",
+          "thumbnail_url": "https://pbs.twimg.com/amplify_video_thumb/2091386788502003712/img/tu9-L1X3CnCzPwMw.jpg",
+          "duration": 28.181,
+          "width": 1080,
+          "height": 1920,
+          "format": "video/mp4",
+          "type": "video",
+          "formats": [
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/pl/0JZw_2KB4qCJLHUW.m3u8?tag=29",
+              "container": "m3u8"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/320x568/sjPsvh0uqupWPSeN.mp4?tag=29",
+              "bitrate": 632000,
+              "container": "mp4",
+              "codec": "h264"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/480x852/jJ8Wa6qEtRlbE4LL.mp4?tag=29",
+              "bitrate": 950000,
+              "container": "mp4",
+              "codec": "h264"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/720x1280/Iw7kHRzNX08EJUeE.mp4?tag=29",
+              "bitrate": 2176000,
+              "container": "mp4",
+              "codec": "h264"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/1080x1920/Z0YlFuuWnsWTyeis.mp4?tag=29",
+              "bitrate": 10368000,
+              "container": "mp4",
+              "codec": "h264"
+            }
+          ],
+          "publisher": null,
+          "variants": [
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/pl/0JZw_2KB4qCJLHUW.m3u8?tag=29",
+              "bitrate": 0,
+              "content_type": "application/x-mpegURL"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/320x568/sjPsvh0uqupWPSeN.mp4?tag=29",
+              "bitrate": 632000,
+              "content_type": "video/mp4"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/480x852/jJ8Wa6qEtRlbE4LL.mp4?tag=29",
+              "bitrate": 950000,
+              "content_type": "video/mp4"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/720x1280/Iw7kHRzNX08EJUeE.mp4?tag=29",
+              "bitrate": 2176000,
+              "content_type": "video/mp4"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/1080x1920/Z0YlFuuWnsWTyeis.mp4?tag=29",
+              "bitrate": 10368000,
+              "content_type": "video/mp4"
+            }
+          ]
+        }
+      ],
+      "videos": [
+        {
+          "id": "2091386788502003712",
+          "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/1080x1920/Z0YlFuuWnsWTyeis.mp4?tag=29",
+          "thumbnail_url": "https://pbs.twimg.com/amplify_video_thumb/2091386788502003712/img/tu9-L1X3CnCzPwMw.jpg",
+          "duration": 28.181,
+          "width": 1080,
+          "height": 1920,
+          "format": "video/mp4",
+          "type": "video",
+          "formats": [
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/pl/0JZw_2KB4qCJLHUW.m3u8?tag=29",
+              "container": "m3u8"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/320x568/sjPsvh0uqupWPSeN.mp4?tag=29",
+              "bitrate": 632000,
+              "container": "mp4",
+              "codec": "h264"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/480x852/jJ8Wa6qEtRlbE4LL.mp4?tag=29",
+              "bitrate": 950000,
+              "container": "mp4",
+              "codec": "h264"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/720x1280/Iw7kHRzNX08EJUeE.mp4?tag=29",
+              "bitrate": 2176000,
+              "container": "mp4",
+              "codec": "h264"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/1080x1920/Z0YlFuuWnsWTyeis.mp4?tag=29",
+              "bitrate": 10368000,
+              "container": "mp4",
+              "codec": "h264"
+            }
+          ],
+          "publisher": null,
+          "variants": [
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/pl/0JZw_2KB4qCJLHUW.m3u8?tag=29",
+              "bitrate": 0,
+              "content_type": "application/x-mpegURL"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/320x568/sjPsvh0uqupWPSeN.mp4?tag=29",
+              "bitrate": 632000,
+              "content_type": "video/mp4"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/480x852/jJ8Wa6qEtRlbE4LL.mp4?tag=29",
+              "bitrate": 950000,
+              "content_type": "video/mp4"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/720x1280/Iw7kHRzNX08EJUeE.mp4?tag=29",
+              "bitrate": 2176000,
+              "content_type": "video/mp4"
+            },
+            {
+              "url": "https://video.twimg.com/amplify_video/2091386788502003712/vid/avc1/1080x1920/Z0YlFuuWnsWTyeis.mp4?tag=29",
+              "bitrate": 10368000,
+              "content_type": "video/mp4"
+            }
+          ]
+        }
+      ]
+    },
+    "twitter_card": "player",
+    "color": null,
+    "provider": "twitter",
+    "reposted_by": null
+  }
+}

--- a/src/modules/twitter.action.test.ts
+++ b/src/modules/twitter.action.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
 import { twitter } from "@module/twitter";
 import type { Message } from "discord.js";
-import { loadFixture, setPhotos, setSensitive } from "./__fixtures__/twitter/load";
+import { loadEmbed, loadFixture, setPhotos, setSensitive } from "./__fixtures__/twitter/load";
 
 // ---- mock Discord Message ----
 
 interface MockOpts {
-	embeds?: Array<{ image?: { width: number; height: number } }>;
+	embeds?: Array<{ image?: { width: number; height: number; url?: string } }>;
 	nsfw?: boolean;
 }
+
+// Real captured embed X renders in place of the media on a sensitive tweet.
+let placeholderEmbed: Record<string, any>;
 
 const makeMessage = (content: string, { embeds = [], nsfw = true }: MockOpts = {}): Message => {
 	const msg = {
@@ -39,6 +42,7 @@ let base: Awaited<ReturnType<typeof loadFixture>>;
 
 beforeEach(async () => {
 	base = await loadFixture("photo-vanilla");
+	placeholderEmbed = await loadEmbed("embed-sensitive-placeholder");
 	// action awaits Bun.sleep(2000) before refetching embeds — skip the wait
 	spyOn(Bun, "sleep").mockResolvedValue(undefined as never);
 });
@@ -109,6 +113,57 @@ describe("twitter.action", () => {
 
 		if (result === false) throw new Error("expected reply");
 		expect(result.result.embeds).toHaveLength(3);
+	});
+
+	it("overrides vanilla single-photo tweet when source only shows the sensitive placeholder", async () => {
+		stubFetch(setSensitive(setPhotos(base, 1)));
+
+		// Placeholder embed must not count as the photo being rendered
+		const result = await run(
+			makeMessage("https://x.com/jane/status/123", { embeds: [placeholderEmbed] })
+		);
+
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.embeds).toHaveLength(1);
+	});
+
+	it("overrides fixup site whose image embeds are all sensitive placeholders", async () => {
+		stubFetch(setSensitive(setPhotos(base, 2)));
+
+		const embeds = [placeholderEmbed, placeholderEmbed];
+		const result = await run(makeMessage("https://fxtwitter.com/jane/status/123", { embeds }));
+
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.embeds).toHaveLength(2);
+	});
+
+	it("rejects the real sensitive tweet in a SFW channel", async () => {
+		stubFetch(await loadFixture("video-sensitive"));
+
+		const result = await run(
+			makeMessage("https://x.com/CosplayerBunbun/status/2091473283229376570", {
+				embeds: [placeholderEmbed],
+				nsfw: false
+			})
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it("rewrites the real sensitive video tweet in a NSFW channel", async () => {
+		stubFetch(await loadFixture("video-sensitive"));
+
+		// This is the message the placeholder embed was captured from. It takes the
+		// video path, so the placeholder never reaches an image gate — the url
+		// filter matters for sensitive *photo* tweets.
+		const result = await run(
+			makeMessage("https://x.com/CosplayerBunbun/status/2091473283229376570", {
+				embeds: [placeholderEmbed]
+			})
+		);
+
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.content).toBe("https://fixupx.com/CosplayerBunbun/status/2091473283229376570");
 	});
 
 	it("rewrites vanilla video tweet to fixupx link (real SpaceX fixture)", async () => {

--- a/src/modules/twitter.action.test.ts
+++ b/src/modules/twitter.action.test.ts
@@ -115,6 +115,39 @@ describe("twitter.action", () => {
 		expect(result.result.embeds).toHaveLength(3);
 	});
 
+	// The bug, on the real fixture it was reported from: a sensitive single-photo
+	// tweet linked with a vanilla url. X unfurls the placeholder, the placeholder
+	// counted as a rendered photo, the single-photo gate skipped the tweet, and
+	// the user was left with grey.
+	it("overrides the real sensitive single-photo tweet behind a placeholder embed", async () => {
+		stubFetch(await loadFixture("photo-sensitive"));
+
+		const result = await run(
+			makeMessage("https://x.com/mnk_disukyamada/status/2091470306557018144?s=12", {
+				embeds: [placeholderEmbed]
+			})
+		);
+
+		if (result === false) throw new Error("expected reply");
+		expect(result.result.embeds).toHaveLength(1);
+		expect(result.result.embeds![0].image?.url).toBe(
+			"https://pbs.twimg.com/media/HQZlKHnasAETrUV.jpg?name=orig"
+		);
+	});
+
+	// Guard the other direction: the single-photo gate must still fire when the
+	// source link really did render the photo.
+	it("still skips a vanilla single-photo tweet whose photo actually rendered", async () => {
+		stubFetch(await loadFixture("photo-sensitive"));
+
+		const embeds = [{ image: { width: 1429, height: 2048, url: "https://pbs.twimg.com/media/HQZlKHnasAETrUV.jpg" } }];
+		const result = await run(
+			makeMessage("https://x.com/mnk_disukyamada/status/2091470306557018144", { embeds })
+		);
+
+		expect(result).toBe(false);
+	});
+
 	it("overrides vanilla single-photo tweet when source only shows the sensitive placeholder", async () => {
 		stubFetch(setSensitive(setPhotos(base, 1)));
 

--- a/src/modules/twitter.test.ts
+++ b/src/modules/twitter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, spyOn, afterEach } from "bun:test";
-import { fetchTweet } from "@module/twitter";
-import { loadFixture } from "./__fixtures__/twitter/load";
+import { fetchTweet, isSensitivePlaceholder } from "@module/twitter";
+import { loadEmbed, loadFixture } from "./__fixtures__/twitter/load";
 
 // Stub global fetch to return a Response-like with .text().
 const stubFetch = (body: unknown) =>
@@ -10,6 +10,27 @@ const stubFetch = (body: unknown) =>
 
 afterEach(() => {
 	mock.restore();
+});
+
+describe("isSensitivePlaceholder", () => {
+	it("matches the real captured placeholder embed", async () => {
+		const embed = await loadEmbed("embed-sensitive-placeholder");
+
+		// The placeholder carries real dimensions, so the width/height filter alone
+		// counts it as a rendered photo — that is why the url check exists.
+		expect(embed.image.width).toBeGreaterThan(0);
+		expect(embed.image.height).toBeGreaterThan(0);
+		expect(isSensitivePlaceholder(embed.image.url)).toBe(true);
+	});
+
+	it("tolerates a query string", () => {
+		expect(isSensitivePlaceholder("https://abs.twimg.com/rweb/ssr/default/v2/og/image.png?format=png")).toBe(true);
+	});
+
+	it("does not match real media or a missing url", () => {
+		expect(isSensitivePlaceholder("https://pbs.twimg.com/media/p0.jpg")).toBe(false);
+		expect(isSensitivePlaceholder(undefined)).toBe(false);
+	});
 });
 
 describe("fetchTweet", () => {
@@ -22,6 +43,18 @@ describe("fetchTweet", () => {
 		expect(tweet).not.toBeNull();
 		expect(tweet?.text).toBe("just setting up my twttr");
 		expect(tweet?.author.screen_name).toBe("jack");
+	});
+
+	it("parses a real FXTwitter response (sensitive video tweet)", async () => {
+		stubFetch(await loadFixture("video-sensitive"));
+
+		const tweet = await fetchTweet(new URL("https://x.com/CosplayerBunbun/status/2091473283229376570"));
+
+		expect(tweet).not.toBeNull();
+		expect(tweet?.possibly_sensitive).toBe(true);
+		// Sensitive tweets are not redacted by the API — only the Discord embed is
+		expect(tweet?.author.screen_name).toBe("CosplayerBunbun");
+		expect(tweet?.media?.videos?.length).toBe(1);
 	});
 
 	it("parses a real FXTwitter response (photo tweet)", async () => {

--- a/src/modules/twitter.ts
+++ b/src/modules/twitter.ts
@@ -12,6 +12,13 @@ const logger = createLogger({
 	minLevel: Bun.env.NODE_ENV === "production" ? 3 : 0
 });
 
+// X serves this generic open graph image in place of the real media when a
+// tweet is marked sensitive.
+const SENSITIVE_PLACEHOLDER_URL = "https://abs.twimg.com/rweb/ssr/default/v2/og/image.png";
+
+export const isSensitivePlaceholder = (imageUrl?: string) =>
+	imageUrl?.split("?")[0] === SENSITIVE_PLACEHOLDER_URL;
+
 export const fetchTweet = async (url: URL) => {
 	const sublogger = logger.getSubLogger({
 		name: "fetchTweet"
@@ -74,8 +81,14 @@ export const twitter: StealthModule = {
 				// Fetch newest version message (Reload embeds)
 				obj.message = await obj.message.channel.messages.fetch(obj.message.id);
 
-				// Count how many images the source link already rendered
-				resolve(obj.message.embeds.filter((embed) => (embed.image?.width ?? 0) > 0 && (embed.image?.height ?? 0) > 0).length);
+				// Count how many images the source link already rendered. Sensitive
+				// tweets embed a placeholder instead of the real media, which tells
+				// us nothing about what the user can actually see.
+				resolve(obj.message.embeds.filter((embed) =>
+					(embed.image?.width ?? 0) > 0 &&
+					(embed.image?.height ?? 0) > 0 &&
+					!isSensitivePlaceholder(embed.image?.url)
+				).length);
 			}),
 			fetchTweet(url)
 		]);


### PR DESCRIPTION
## Problem

X now unfurls sensitive tweets with a generic open graph placeholder instead of showing nothing:
`https://abs.twimg.com/rweb/ssr/default/v2/og/image.png`

It arrives with real dimensions (1202x634), so it passed the `width`/`height` filter and `imageEmbedCount` counted it as a photo the source link had already rendered. A vanilla single-photo tweet then hit the `hasImageEmbed && images.length === 1` gate and got skipped — leaving the user with a placeholder and nothing else.

## Fix

Filter embeds by that url before counting them.

Keyed on the url, not `possibly_sensitive` — a sensitive tweet that *does* render its media should still be left alone, and the flag cannot tell the two cases apart. (No such cases is observed yet, but just in case.)

## Testing

Fixtures captured live and committed:

- `embed-sensitive-placeholder.json` — the real Discord embed
- `photo-sensitive.json` — the reported single-photo tweet, the case this fixes
- `video-sensitive.json` — a sensitive video tweet, for schema shape and the NSFW gate

Note: Both envelopes contain NSFW media urls.

The bug is reproduced, not assumed: with the placeholder filter removed, the single-photo test fails with `expected reply`, because the placeholder is counted and the gate skips the tweet. Restoring the filter passes.

23 tests pass. Coverage: placeholder detection including query strings, the real single-photo override, the opposite guard (a vanilla single-photo tweet whose photo *really* rendered is still skipped, so the filter did not just disable that gate), and the video fixture through both the SFW reject and NSFW rewrite paths. The fixup-site placeholder test is defensive only, per the section above.