### PR TITLE
fix(privacy): delete Ignore rows on /forgetme

### DIFF
--- a/src/commands/setting/forgetme.ts
+++ b/src/commands/setting/forgetme.ts
@@ -14,6 +14,13 @@ class Command extends SlashApplicationCommand {
 			}
 		});
 
+		await client.ignore.deleteMany({
+			where: {
+				id: interaction.user.id,
+				type: "u"
+			}
+		});
+
 		return {
 			content: t("forgetme.success")
 		};


### PR DESCRIPTION
## Problem

`/forgetme` only deleted `Language` rows. A user's `Ignore` row — keyed to their Discord user id — survived, so "forget your data" left data behind.

## Fix

Delete the user's `Ignore` rows too.

## Side effect that needs a decision

Deleting the `Ignore` row **silently reverses `/ignoreme`**. Practically, the forget command should override the ignore command - it's making the bot *forget* about you, after all.