### PR TITLE
Add support to multiple pixiv proxy hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ error_chid=
 saucenao_key=
 safebrowsing_key=
 pixiv_refresh_token=
+# Comma-separated i.pximg.net reverse proxies, tried in order. Defaults to i.pixiv.cat.
+pixiv_proxy_hosts=i.pixiv.cat,i.loli.best
 imgur_id=
 imgur_secret=
 exchangerate_key=

--- a/README.md
+++ b/README.md
@@ -37,9 +37,27 @@ yarn start
 | Name | Purposes |
 | ---- | -------- |
 |[pixiv](https://www.pixiv.net/en/)|Fetch images from pixiv|
+|[pixiv.cat](https://pixiv.cat/)|Serve pixiv images past the `i.pximg.net` hotlink block|
+|i.loli.best|Same, used as fallback when pixiv.cat is unreachable|
 |[saucenao](https://saucenao.com/)|Reverse image search|
 |[exchangerate.host](https://exchangerate.host/)|Currency conversion|
 |[Google Safebrowsing](https://safebrowsing.google.com/)|Detect malicious URLs|
 |[FXTwitter](https://github.com/FixTweet/FixTweet)|Generate embeds from Twitter links|
 |[facebed](https://facebed.com/)|Generate embeds from Facebook links|
 |[vxbilibili](https://www.vxbilibili.com/)|Generate embeds from Bilibili links|
+
+### pixiv image proxies
+
+`i.pximg.net` rejects hotlinked requests, so images are served through a reverse
+proxy that re-sends them with a `pixiv.net` Referer. These are free third-party
+services run by volunteers — please do not hammer them, and consider self-hosting
+if you run a busy instance.
+
+Set `pixiv_proxy_hosts` in `.env` to a comma-separated list; hosts are tried in
+order, and one that fails is skipped for 5 minutes. Any proxy mirroring the
+`i.pximg.net` path scheme works, so a self-hosted one can simply go first in the
+list. These have been verified to work: `i.pixiv.cat`, `i.loli.best`,
+`i.pixiv.nl`, `i.pixiv.re`.
+
+Public proxies do disappear — `i.yuki.sh`, used until v3.6.1, stopped resolving
+entirely. That is why the list is configurable.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yarn start
 | ---- | -------- |
 |[pixiv](https://www.pixiv.net/en/)|Fetch images from pixiv|
 |[pixiv.cat](https://pixiv.cat/)|Serve pixiv images past the `i.pximg.net` hotlink block|
-|i.loli.best|Same, used as fallback when pixiv.cat is unreachable|
+|[i.loli.best](https://github.com/Tsuk1ko/pximg-proxy)|Same, used as fallback when pixiv.cat is unreachable|
 |[saucenao](https://saucenao.com/)|Reverse image search|
 |[exchangerate.host](https://exchangerate.host/)|Currency conversion|
 |[Google Safebrowsing](https://safebrowsing.google.com/)|Detect malicious URLs|
@@ -49,15 +49,32 @@ yarn start
 ### pixiv image proxies
 
 `i.pximg.net` rejects hotlinked requests, so images are served through a reverse
-proxy that re-sends them with a `pixiv.net` Referer. These are free third-party
-services run by volunteers — please do not hammer them, and consider self-hosting
-if you run a busy instance.
+proxy that re-sends them with a `pixiv.net` Referer. Thanks to the people running
+these for free:
+
+* **[pixiv.cat](https://pixiv.cat/)** — source at
+  [pixiv-cat/pixivcat-backend](https://github.com/pixiv-cat/pixivcat-backend)
+  (Node.js + Express, Memcached, MIT).
+* **[i.loli.best](https://github.com/Tsuk1ko/pximg-proxy)** — the public demo
+  instance of [Tsuk1ko/pximg-proxy](https://github.com/Tsuk1ko/pximg-proxy)
+  (TypeScript + Hono, runs on Node.js ≥18 or Bun, Dockerfile included, MIT).
+
+Please do not hammer them. `i.loli.best` is explicitly a demo instance, not a
+service with an uptime promise, so anything busy should self-host. Both projects
+ship a deployable server; `pximg-proxy` also runs serverless, but note it needs
+pixiv credentials of its own (a `PHPSESSID` cookie or a client refresh token).
 
 Set `pixiv_proxy_hosts` in `.env` to a comma-separated list; hosts are tried in
 order, and one that fails is skipped for 5 minutes. Any proxy mirroring the
-`i.pximg.net` path scheme works, so a self-hosted one can simply go first in the
-list. These have been verified to work: `i.pixiv.cat`, `i.loli.best`,
-`i.pixiv.nl`, `i.pixiv.re`.
+`i.pximg.net` path scheme works, so a self-hosted instance can simply go first in
+the list. Verified working: `i.pixiv.cat`, `i.loli.best`, `i.pixiv.nl`,
+`i.pixiv.re`.
+
+Pick hosts from *different operators*. pixiv.cat's own site lists `pixiv.re` and
+`pixiv.nl` as its backup mirror domains, so `i.pixiv.cat`, `i.pixiv.re` and
+`i.pixiv.nl` share one backend and tend to fail together — the shipped default
+pairs `i.pixiv.cat` with `i.loli.best` precisely because those two are
+independent.
 
 Public proxies do disappear — `i.yuki.sh`, used until v3.6.1, stopped resolving
 entirely. That is why the list is configurable.

--- a/src/modules/pixiv.test.ts
+++ b/src/modules/pixiv.test.ts
@@ -5,8 +5,12 @@ import type { PixivIllustItem } from "@book000/pixivts";
 const dir = `${import.meta.dir}/__fixtures__/pixiv`;
 const loadItem = () => Bun.file(`${dir}/illust-single.json`).json();
 
-// toMessage does HEAD fetches to warm the CDN — stub them.
-const stubFetch = () => spyOn(globalThis, "fetch").mockResolvedValue({} as Response);
+// Pin the proxy list so a developer's local .env can't change what we assert.
+Bun.env.pixiv_proxy_hosts = "i.pixiv.cat";
+
+// toMessage HEAD-probes the proxy to pick a host and warm the CDN — stub it.
+// The probe treats a non-ok response as a dead host, so ok must be true.
+const stubFetch = () => spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as Response);
 
 afterEach(() => mock.restore());
 
@@ -36,9 +40,9 @@ describe("pixiv Illust.toMessage (embed building)", () => {
 		if (!msg?.embeds) throw new Error("expected embeds");
 		expect(msg.embeds).toHaveLength(1);
 		const embed = msg.embeds[0] as any;
-		// i.pximg.net proxied to i.yuki.sh
+		// i.pximg.net proxied to the first reachable host
 		expect(embed.image.url).toBe(
-			"https://i.yuki.sh/img-original/img/2024/01/01/00/00/00/123456_p0.png"
+			"https://i.pixiv.cat/img-original/img/2024/01/01/00/00/00/123456_p0.png"
 		);
 		expect(embed.color).toBe(0x3D92F5);
 		expect(embed.footer.text).toContain("100"); // total_bookmarks
@@ -78,5 +82,47 @@ describe("pixiv Illust.toMessage (embed building)", () => {
 
 		const msg = await new Illust(item as PixivIllustItem).toMessage(true);
 		expect((msg?.embeds?.[0] as any).image).toBeDefined();
+	});
+});
+
+describe("pixiv proxy failover", () => {
+	// Each test uses fresh host names — the cooldown map is module-scoped and
+	// would otherwise leak a disabled host into the next test.
+	const stubHosts = (deadHost: string) =>
+		spyOn(globalThis, "fetch").mockImplementation(async (input: any) =>
+			(input as string).includes(deadHost) ?
+				Promise.reject(new Error("ECONNREFUSED")) :
+				({ ok: true } as Response)
+		);
+
+	afterEach(() => { Bun.env.pixiv_proxy_hosts = "i.pixiv.cat"; });
+
+	it("falls through to the next host when the first is unreachable", async () => {
+		Bun.env.pixiv_proxy_hosts = "dead-1.test,alive-1.test";
+		stubHosts("dead-1.test");
+
+		const msg = await new Illust((await loadItem()) as PixivIllustItem).toMessage(false);
+
+		expect((msg?.embeds?.[0] as any).image.url).toBe(
+			"https://alive-1.test/img-original/img/2024/01/01/00/00/00/123456_p0.png"
+		);
+	});
+
+	it("skips a host that answers with a non-OK status", async () => {
+		Bun.env.pixiv_proxy_hosts = "dead-2.test,alive-2.test";
+		spyOn(globalThis, "fetch").mockImplementation(async (input: any) =>
+			({ ok: !(input as string).includes("dead-2.test") } as Response)
+		);
+
+		const msg = await new Illust((await loadItem()) as PixivIllustItem).toMessage(false);
+
+		expect((msg?.embeds?.[0] as any).image.url).toContain("https://alive-2.test/");
+	});
+
+	it("returns null when every host is down", async () => {
+		Bun.env.pixiv_proxy_hosts = "dead-3.test,dead-4.test";
+		spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+		expect(await new Illust((await loadItem()) as PixivIllustItem).toMessage(false)).toBeNull();
 	});
 });

--- a/src/modules/pixiv.ts
+++ b/src/modules/pixiv.ts
@@ -28,7 +28,51 @@ const getPixivClient = async (): Promise<Pixiv> => {
 	return pixivClient;
 };
 
-const proxy = (url: string) => url.replace("i.pximg.net", "i.yuki.sh");
+// i.pximg.net rejects hotlinking, so images are served through a reverse proxy
+// that re-sends the request with a pixiv.net Referer. Public proxies disappear
+// without warning (i.yuki.sh did), so the host list is configurable and we fail
+// over in order rather than trusting a single one.
+const DEFAULT_PROXY_HOST = "i.pixiv.cat";
+const PROXY_COOLDOWN_MS = 5 * 60 * 1000;
+
+// Read lazily so tests can set the env var after import.
+const proxyHosts = () => (Bun.env.pixiv_proxy_hosts ?? DEFAULT_PROXY_HOST)
+	.split(",")
+	.map((host) => host.trim())
+	.filter(Boolean);
+
+const disabledUntil = new Map<string, number>();
+
+const proxy = (url: string, host: string) => url.replace("i.pximg.net", host);
+
+// Returns the first host serving every URL, or null if all of them are down.
+// The probe doubles as the CDN cache warm-up, so this costs no extra requests.
+const pickHost = async (urls: string[]): Promise<string | null> => {
+	const sublogger = logger.getSubLogger({ name: "pickHost" });
+	const now = Date.now();
+
+	for (const host of proxyHosts()) {
+		if ((disabledUntil.get(host) ?? 0) > now) {
+			continue;
+		}
+
+		try {
+			const responses = await Promise.all(
+				urls.map((url) => fetch(proxy(url, host), { method: "HEAD" }))
+			);
+			if (responses.every((res) => res.ok)) {
+				return host;
+			}
+			sublogger.warn(`${host} returned a non-OK status, trying next host`);
+		} catch (e) {
+			sublogger.warn(`${host} is unreachable, trying next host`, e);
+		}
+
+		disabledUntil.set(host, now + PROXY_COOLDOWN_MS);
+	}
+
+	return null;
+};
 
 export class Illust {
 	protected sublogger: Logger<any>;
@@ -47,22 +91,24 @@ export class Illust {
 		});
 
 		try {
-			const imageUrls = (this.item.page_count === 1 ?
+			const rawImageUrls = (this.item.page_count === 1 ?
 				[this.item.meta_single_page.original_image_url!] :
 				this.item.meta_pages.map((page) => page.image_urls.original))
-				.slice(0, 10) // Discord API Limit
-				.map(proxy);
-			
+				.slice(0, 10); // Discord API Limit
+			const rawIconUrl = this.item.user.profile_image_urls.medium;
+
+			const host = await pickHost([rawIconUrl, ...rawImageUrls]);
+			if (!host) {
+				sublogger.error("Every pixiv image proxy is unreachable");
+				return null;
+			}
+
+			const imageUrls = rawImageUrls.map((url) => proxy(url, host));
+			const iconUrl = proxy(rawIconUrl, host);
+
 			sublogger.debug("imageUrls", imageUrls);
 
 			let embeds: APIEmbed[];
-
-			// Try to hint the CDN to cache our files
-			for (const imageUrl of [proxy(this.item.user.profile_image_urls.medium), ...imageUrls]) {
-				await fetch(imageUrl, {
-					method: "HEAD"
-				});
-			}
 
 			embeds = imageUrls.map((url) => ({
 				image: {
@@ -88,7 +134,7 @@ export class Illust {
 				...{
 					author: {
 						name: this.item.title ? `${prefix} ${this.item.title} ${suffix}` : t(`${prefix} $t(pixiv.titlePlaceholder) ${suffix}`),
-						icon_url: proxy(this.item.user.profile_image_urls.medium),
+						icon_url: iconUrl,
 						url: `https://www.pixiv.net/artworks/${this.item.id}`
 					},
 					color: this.item.x_restrict > 0 ? 0xd37a52 : 0x3D92F5,


### PR DESCRIPTION
## Problem

`i.yuki.sh` no longer resolves:

```
i.yuki.sh   -> could not resolve host (NXDOMAIN)
yuki.sh     -> resolves, 301, Cloudflare
```

The apex still answers, so the subdomain was removed deliberately rather than being a transient outage. Every pixiv embed has been broken since — the images pointed at a host that does not exist.

## Change

Replaces the hardcoded proxy host with a comma-separated `pixiv_proxy_hosts` list, tried in order, with a 5 minute cooldown on a host that fails.

The existing CDN warm-up loop becomes the health probe, so host selection costs no extra requests: HEAD every URL for the illust, take the first host that serves all of them. When no host is reachable, `toMessage` returns `null`, which the module already handles by not replying.

Code default is `i.pixiv.cat` alone; `.env.example` ships `i.pixiv.cat,i.loli.best`
so deployments get failover without the default carrying a list.

## Tests

`bun run test` — 52 pass, 2 skip, 0 fail.

Added three failover cases: first host refuses the connection, first host answers a non-OK status, and every host down.

The existing fetch stub returned `{}`, and `.ok` on that is `undefined`, which the new probe reads as a dead host — it now returns `{ ok: true }`. The proxy list is pinned in the test file so a local `.env` cannot shift assertions.